### PR TITLE
Fixing covr usecase

### DIFF
--- a/R/testthat.R
+++ b/R/testthat.R
@@ -114,7 +114,7 @@ expect_no_error <- function(object, ...) {
 #'
 #' @export
 test_examples_as_testthat <- function(package, path, ...,
-  test_dir = tempfile("testex"), clean = TRUE, overwrite = TRUE,
+  test_dir = tempfile("testex"), quiet = TRUE, clean = TRUE, overwrite = TRUE,
   reporter = testthat::get_reporter()) {
 
   requireNamespace("testthat")
@@ -154,8 +154,8 @@ test_examples_as_testthat <- function(package, path, ...,
     # write out test code to file in test dir
     path <- file.path(test_dir, paste0(tools::file_path_sans_ext(rd_filename), ".R"))
     example_code <- vcapply(exprs, deparse_pretty)
-    writeLines(paste(example_code, collapse = "\n\n"), path)
 
+    writeLines(paste(example_code, collapse = "\n\n"), path)
     path
   })
 

--- a/R/utils_rd.R
+++ b/R/utils_rd.R
@@ -1,14 +1,25 @@
 find_package_rds <- function(package, path = getwd()) {
   if (!missing(package)) {
     package_path <- find.package(package, quiet = TRUE)
-    package_man <- file.path(package_path, "man")
-    if (isTRUE(dir.exists(package_man))) rds <- tools::Rd_db(dir = package_path)
-    else rds <- tools::Rd_db(package)
   } else {
-    desc <- file.path(find_package_root(path), "DESCRIPTION")
-    package <- read.dcf(desc, fields = "Package")[[1L]]
-    rds <- tools::Rd_db(dir = path)
+    package_path <- find_package_root(path)
   }
+
+  desc <- file.path(package_path, "DESCRIPTION")
+  package <- read.dcf(desc, fields = "Package")[[1L]]
+
+  has_R_dir <- isTRUE(dir.exists(file.path(package_path, "R")))
+  has_Meta_dir <- isTRUE(dir.exists(file.path(package_path, "Meta")))
+
+  if (has_R_dir && !has_Meta_dir) {
+    return(tools::Rd_db(dir = package_path))
+  }
+
+  if (has_Meta_dir) {
+    return(tools::Rd_db(package = package, lib.loc = dirname(package_path)))
+  }
+
+  tools::Rd_db(package)
 }
 
 rd_extract_examples <- function(rd) {

--- a/R/utils_srcref.R
+++ b/R/utils_srcref.R
@@ -52,7 +52,11 @@ srclocs <- function(x, file) {
     line <- x[[2]]
     x[[3]] <- x[[2]]
     x[[2]] <- 0
-    x[[4]] <- nchar(scan(file, what = character(), skip = line - 1, n = 1, quiet = TRUE))
+    x[[4]] <- if (file.exists(file)) file_line_nchar(file, line) else 0
   }
   x
+}
+
+file_line_nchar <- function(file, line) {
+  nchar(scan(file, what = character(), skip = line - 1, n = 1, quiet = TRUE))
 }

--- a/inst/pkg.example/R/fn.R
+++ b/inst/pkg.example/R/fn.R
@@ -59,11 +59,11 @@ fn_roxygen <- function(x) {
 #' @param x A thing
 #'
 #' @examples
-#' fn_roxygen("testing")
+#' fn_roxygen_testthat("testing")
 #' @testthat expect_equal("testing 1 2 3")
-#' @testthat expect_match("^tasting")
+#' @testthat expect_match("^testing")
 #'
-#' fn_roxygen(stop(3))
+#' fn_roxygen_testthat("testing")
 #' @testthat expect_equal("testing 1 2 3")
 #' @testthat expect_match("^testing")
 #'

--- a/inst/pkg.example/man/fn_roxygen_testthat.Rd
+++ b/inst/pkg.example/man/fn_roxygen_testthat.Rd
@@ -13,17 +13,17 @@ fn_roxygen_testthat(x)
 Test Function
 }
 \examples{
-fn_roxygen("testing") \testonly{
-testex::testthat_block(test_that("`fn_roxygen_testthat` example (fn.R:61:62)", {
+fn_roxygen_testthat("testing") \testonly{
+testex::testthat_block(test_that("`fn_roxygen_testthat` example tests (fn.R:61:62)", {
   testex::with_srcref("fn.R:63:63", expect_equal(., "testing 1 2 3"))
-  testex::with_srcref("fn.R:64:64", expect_match(., "^tasting"))
+  testex::with_srcref("fn.R:64:64", expect_match(., "^testing"))
 }),
   obj     = "fn_roxygen_testthat",
   example = "fn.R:61:62"
 )}
 
-fn_roxygen(stop(3)) \testonly{
-testex::testthat_block(test_that("`fn_roxygen_testthat` example (fn.R:65:66)", {
+fn_roxygen_testthat("testing") \testonly{
+testex::testthat_block(test_that("`fn_roxygen_testthat` example tests (fn.R:65:66)", {
   testex::with_srcref("fn.R:67:67", expect_equal(., "testing 1 2 3"))
   testex::with_srcref("fn.R:68:68", expect_match(., "^testing"))
 }),

--- a/inst/pkg.example/tests/testthat/test-testex.R
+++ b/inst/pkg.example/tests/testthat/test-testex.R
@@ -1,1 +1,1 @@
-testex::test_examples_as_testthat()
+testex::test_examples_as_testthat(quiet = FALSE)

--- a/man/test_examples_as_testthat.Rd
+++ b/man/test_examples_as_testthat.Rd
@@ -6,11 +6,12 @@
 \usage{
 test_examples_as_testthat(
   package,
-  path = getwd(),
+  path,
   ...,
   test_dir = tempfile("testex"),
+  quiet = TRUE,
   clean = TRUE,
-  regenerate = TRUE,
+  overwrite = TRUE,
   reporter = testthat::get_reporter()
 )
 }


### PR DESCRIPTION
Fixes a few assumptive patterns when trying to find package root and when producing srcrefs. Now should also work for installed packages and have a safe fallback when srcref file target does not exist.